### PR TITLE
Fix code block styling for dark mode

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -6,7 +6,8 @@
     <title>{{ title or metadata.title }}</title>
     <meta name="description" content="{{ description or metadata.description }}">
     <link rel="stylesheet" href="/src/styles/global.css">
-    <link rel="stylesheet" href="https://unpkg.com/prismjs@1.20.0/themes/prism-solarizedlight.css">
+    <link rel="stylesheet" href="https://unpkg.com/prismjs@1.20.0/themes/prism-solarizedlight.css" media="(prefers-color-scheme: light)">
+    <link rel="stylesheet" href="https://unpkg.com/prismjs@1.20.0/themes/prism-tomorrow.css" media="(prefers-color-scheme: dark)">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Merriweather:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,6 +65,11 @@ pre[class*="language-"] {
     border-radius: 0.3rem;
 }
 
+code[class*="language-"],
+pre[class*="language-"] {
+    background-color: var(--code-bg-color) !important;
+}
+
 .site-title {
     font-size: 2.5rem;
     line-height: 1.1;


### PR DESCRIPTION
The code blocks in the blog were not adapting to the system dark mode because the Prism.js Solarized Light theme was hardcoded with a fixed background color. I've updated the base layout to load Solarized Light for light mode and Tomorrow (a dark theme) for dark mode. I also ensured that the code block background color is unified with the site's theme variables.

---
*PR created automatically by Jules for task [3936418284980700417](https://jules.google.com/task/3936418284980700417) started by @helloworldless*